### PR TITLE
🔊 Add start / stop messages / close zombie server

### DIFF
--- a/pdp.el
+++ b/pdp.el
@@ -55,12 +55,19 @@
         (message "[Piglet] PDP server started on port: 17017"))
     (message "[Piglet] PDP server already running.")))
 
-(defun pdp-stop-server! ()
-  (interactive)
+(defun pdp-stop-server! (prefix)
+  "Stop the PDP server. With PREFIX, force closes the zombie server on 17017.
+
+   Force closing the server may be needed for default webscoket server when the
+   pointer to the existing connection is lost, mostly only useful during
+   development or if it got in a bad state somehow."
+  (interactive "P")
   (when pdp--server
     (websocket-server-close pdp--server))
   (setq pdp--server nil)
   (setq pdp--connections nil)
+  (when prefix
+    (delete-process "websocket server on port 17017"))
   (message "[Piglet] PDP server stopped."))
 
 (defun pdp-msg (kvs)

--- a/pdp.el
+++ b/pdp.el
@@ -43,21 +43,25 @@
 
 (defun pdp-start-server! ()
   (interactive)
-  (when (not pdp--server)
-    (setq pdp--server
-          (websocket-server
-           17017
-           :host 'local
-           :on-open #'pdp--on-open
-           :on-message #'pdp--on-message
-           :on-close #'pdp--on-close))))
+  (if (not pdp--server)
+      (progn
+        (setq pdp--server
+              (websocket-server
+               17017
+               :host 'local
+               :on-open #'pdp--on-open
+               :on-message #'pdp--on-message
+               :on-close #'pdp--on-close))
+        (message "[Piglet] PDP server started on port: 17017"))
+    (message "[Piglet] PDP server already running.")))
 
 (defun pdp-stop-server! ()
   (interactive)
   (when pdp--server
     (websocket-server-close pdp--server))
   (setq pdp--server nil)
-  (setq pdp--connections nil))
+  (setq pdp--connections nil)
+  (message "[Piglet] PDP server stopped."))
 
 (defun pdp-msg (kvs)
   (append


### PR DESCRIPTION
* adds start stop message
* provides a force closure prefix argument for `pdp-stop-server!` very handy to kill zombie websocket server